### PR TITLE
Allow for autoprovisioning of API keys from rancher using the Service…

### DIFF
--- a/templates/openfaas/1/README.md
+++ b/templates/openfaas/1/README.md
@@ -1,0 +1,3 @@
+This is a catalog that spins up an OpenFaaS(https://github.com/alexellis/faas) stack with Rancher as the backend. The `faas-rancher` container is the proxy that connects OpenFaas and Rancher.
+
+`faas-rancher` is in an extremely early stage and is meant only to be used in development.

--- a/templates/openfaas/1/docker-compose.yml
+++ b/templates/openfaas/1/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '2'
+services:
+  lb:
+    image: rancher/lb-service-haproxy:v0.7.9
+    ports:
+    - 8080:8080/tcp
+    - 9090:9090/tcp
+    - 9093:9093/tcp
+    labels:
+      io.rancher.container.agent.role: environmentAdmin
+      io.rancher.container.create_agent: 'true'
+  prometheus:
+    image: kenfdev/prometheus:latest-cattle
+    environment:
+      no_proxy: gateway
+    stdin_open: true
+    tty: true
+    command:
+    - -config.file=/etc/prometheus/prometheus.yml
+    - -storage.local.path=/prometheus
+    - -storage.local.memory-chunks=10000
+    - --alertmanager.url=http://alertmanager:9093
+    labels:
+      io.rancher.container.pull_image: always
+  faas-rancher:
+    image: kenfdev/faas-rancher
+    environment:
+      FUNCTION_STACK_NAME: ${FUNCTION_STACK_NAME}
+    stdin_open: true
+    tty: true
+    labels:
+      io.rancher.container.pull_image: always
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent.role: environment
+  gateway:
+    image: functions/gateway:0.6.2
+    environment:
+      dnsrr: 'true'
+      functions_provider_url: http://faas-rancher:8080/
+    stdin_open: true
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    tty: true
+    labels:
+      io.rancher.container.pull_image: always
+  alertmanager:
+    image: functions/alertmanager:latest
+    environment:
+      no_proxy: gateway
+    stdin_open: true
+    tty: true
+    command:
+    - -config.file=/alertmanager.yml
+    labels:
+      io.rancher.container.pull_image: always

--- a/templates/openfaas/1/rancher-compose.yml
+++ b/templates/openfaas/1/rancher-compose.yml
@@ -1,0 +1,57 @@
+.catalog:
+  name: "OpenFaaS"
+  version: "v0.1.0"
+  description: "Enable Rancher as a backend for Functions as a Service (OpenFaaS)"
+  uuid: "openfaas-0"
+  minimum_rancher_version: v1.6.0
+  questions:
+     - variable: "FUNCTION_STACK_NAME"
+       default: "faas-functions"
+       description: "The stack name faas functions will be deployed to. If it doesn't exist, it will be created automatically."
+       label: "Functions Stack Name"
+       required: true
+       type: "string"
+
+version: '2'
+services:
+  lb:
+    scale: 1
+    start_on_create: true
+    lb_config:
+      certs: []
+      port_rules:
+      - priority: 1
+        protocol: http
+        service: gateway
+        source_port: 8080
+        target_port: 8080
+      - priority: 2
+        protocol: http
+        service: prometheus
+        source_port: 9090
+        target_port: 9090
+      - priority: 3
+        protocol: http
+        service: alertmanager
+        source_port: 9093
+        target_port: 9093
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 42
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 2000
+      reinitializing_timeout: 60000
+  prometheus:
+    scale: 1
+    start_on_create: true
+  faas-rancher:
+    scale: 1
+    start_on_create: true
+  gateway:
+    scale: 1
+    start_on_create: true
+  alertmanager:
+    scale: 1
+    start_on_create: true


### PR DESCRIPTION
The above/below labels allow for a API key for the provisioned environment, removing the requirement in providing these on start up, as documented here: http://rancher.com/docs/rancher/latest/en/rancher-services/service-accounts/

This removes the requirement for the questions at startup, and also allows for easier (automated) deployments.

I've added this as a new version of `v0.1.0` as this could be a potential breaking change, should users by running a rancher server <= 1.5.0